### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ temp:
 
 package: temp
 	cd tmp && tar -czvf hiredis.tgz hiredis
+
+check:
+	npm test


### PR DESCRIPTION
Add "make check" rule to perform testing and fix "all" rule to automatically initialize submodules when missing. See #12
