### PR TITLE
Use redis/hiredis for hiredis submodule ref

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/hiredis"]
 	path = deps/hiredis
-	url = git://github.com/antirez/hiredis.git
+	url = git://github.com/redis/hiredis.git


### PR DESCRIPTION
The hiredis repo moved from antirez/hiredis to redis/hiredis, so the ref needs to point to the new repo.
