### PR TITLE
Added solaris build support

### DIFF
--- a/deps/hiredis.gyp
+++ b/deps/hiredis.gyp
@@ -17,6 +17,9 @@
           'xcode_settings': {
             'GCC_C_LANGUAGE_STANDARD': 'c99'
           }
+        }],
+        ['OS=="solaris"', {
+          'cflags': ['-std=c99']
         }]
       ]
     }


### PR DESCRIPTION
hiredis is well known for failing inside nodejitsu and the SmartOS
this fixes it.
