### PR TITLE
Updated hiredis link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ benefit to using hiredis.
 If you use Redis for big SUNION/SINTER/LRANGE/ZRANGE operations, the
 benefit to using hiredis-node can be significant.
 
-[hiredis]: http://github.com/antirez/hiredis
+[hiredis]: http://github.com/redis/hiredis
 
 ## Install
 


### PR DESCRIPTION
As the [hiredis README](https://github.com/antirez/hiredis/blob/master/README.md) shows, the project has moved to https://github.com/redis/hiredis.
