### PR TITLE
Patch for Node 0.11.3

### DIFF
--- a/src/reader.h
+++ b/src/reader.h
@@ -40,7 +40,7 @@ private:
      * replies. This defaults to false, so strings are returned by default. */
     bool return_buffers;
 
-    #if NODE_MODULE_VERSION < 12
+    #if !NODE_VERSION_AT_LEAST(0, 11, 3)
         /* Use a buffer pool like the fast buffers. */
         Local<Value> createBufferFromPool(char *str, size_t len);
         Persistent<Function> buffer_fn;


### PR DESCRIPTION
Node 0.11.3 changed the Buffer API. Now it should not be necessary with a custom pooling implementation. According to the documentation, Buffers less than 4kb are transparently sliced from a larger Buffer.
