### PR TITLE
Fix for use on Nodejitsu

### DIFF
--- a/deps/hiredis.gyp
+++ b/deps/hiredis.gyp
@@ -17,6 +17,9 @@
           'xcode_settings': {
             'GCC_C_LANGUAGE_STANDARD': 'c99'
           }
+        }],
+        ['OS=="solaris"', {
+          'cflags+': [ '-std=c99' ]
         }]
       ]
     }


### PR DESCRIPTION
This fixes an `npm install` issue on SmartOS (used by nodejitsu.com) when `hiredis-node` is listed as a dependency in a package.json file for a NodeJS project.

`hiredis-node` [fails](https://gist.github.com/randomfactor/6096808/raw/4a9117da8871148696eaf249522c064f2f09d15b/gistfile1.txt) _jitsu deploy_ during `npm install` step on Nodejitsu.com. There are [workarounds](http://stackoverflow.com/questions/12061494/how-to-fix-hiredis-compilation-issue-on-nodejitsu) for using with connect-redis (which just falls back to using the built-in node reader). However, other npm packages (eg. then-couchdb) have a dependency on hiredis-node, but do not have a known workaround.
