### PR TITLE
[feature] - repo and url is showed in packaje.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,12 @@
   },
   "engines": {
     "node": ">= 0.6.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:pietern/hiredis-node.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pietern/hiredis-node/issues"
   }
 }


### PR DESCRIPTION
To make npm happy, because it complains

``` shell
[nap@rhel mwc_kernel]$ npm install
npm WARN package.json hiredis@0.1.15 No repository field.
```
