### PR TITLE
Fix unicode in `write()`, support non-string args. 

### DIFF
--- a/hiredis.js
+++ b/hiredis.js
@@ -2,18 +2,24 @@ var net = require("net"),
     hiredis = require('bindings')('hiredis.node');
 
 exports.Reader = hiredis.Reader;
+
+exports.writeCommand = function() {
+    var i, args = arguments;
+    var str = "*" + args.length + "\r\n";
+    for (i = 0; i < args.length; i++) {
+        var arg = args[i];
+        str += "$" + arg.length + "\r\n" + arg + "\r\n";
+    }
+    return str;
+}
+
 exports.createConnection = function(port, host) {
     var s = net.createConnection(port || 6379, host);
     var r = new hiredis.Reader();
     var _write = s.write;
 
     s.write = function() {
-        var i, args = arguments;
-        var str = "*" + args.length + "\r\n";
-        for (i = 0; i < args.length; i++) {
-            var arg = args[i];
-            str += "$" + arg.length + "\r\n" + arg + "\r\n";
-        }
+        var str = exports.writeCommand.apply(this, arguments);
         return _write.call(s, str);
     }
 

--- a/hiredis.js
+++ b/hiredis.js
@@ -9,11 +9,12 @@ exports.createConnection = function(port, host) {
 
     s.write = function() {
         var i, args = arguments;
-        _write.call(s, "*" + args.length + "\r\n");
+        var str = "*" + args.length + "\r\n";
         for (i = 0; i < args.length; i++) {
             var arg = args[i];
-            _write.call(s, "$" + arg.length + "\r\n" + arg + "\r\n");
+            str += "$" + arg.length + "\r\n" + arg + "\r\n";
         }
+        return _write.call(s, str);
     }
 
     s.on("data", function(data) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Pieter Noordhuis <pcnoordhuis@gmail.com>",
   "main": "hiredis",
   "scripts": {
-    "test": "node test/reader.js"
+    "test": "node test/reader.js && node test/writer.js"
   },
   "dependencies": {
     "bindings": "*",

--- a/test/reader.js
+++ b/test/reader.js
@@ -1,19 +1,6 @@
 var assert = require("assert"),
+    test = require("./testlib")(),
     hiredis = require("../hiredis");
-
-var passed = 0;
-var failed = 0;
-
-function test(str, fn) {
-    try {
-        fn();
-        passed++;
-    } catch (err) {
-        console.log("\x1B[1;31m" + str + " failed!\x1B[0m");
-        console.log(err.stack + "\n");
-        failed++;
-    }
-}
 
 test("CreateReader", function() {
     var reader = new hiredis.Reader();
@@ -172,7 +159,7 @@ test("UndefinedReplyOnIncompleteFeed", function() {
     assert.deepEqual("foo", reader.get());
 });
 
-test("Leaks", function(beforeExit) {
+test("Leaks", function() {
     /* The "leaks" utility is only available on OSX. */
     if (process.platform != "darwin") return;
 

--- a/test/testlib.js
+++ b/test/testlib.js
@@ -1,0 +1,17 @@
+module.exports = function() {
+    function test(str, fn) {
+        try {
+            fn();
+            test.passed++;
+        } catch (err) {
+            console.log("\x1B[1;31m" + str + " failed!\x1B[0m");
+            console.log(err.stack + "\n");
+            test.failed++;
+        }
+    }
+
+    test.passed = 0;
+    test.failed = 0;
+
+    return test;
+}

--- a/test/writer.js
+++ b/test/writer.js
@@ -1,0 +1,9 @@
+var assert = require("assert"),
+    test = require("./testlib")(),
+    hiredis = require("../hiredis");
+
+test("WriteCommand", function() {
+    var reader = new hiredis.Reader();
+    reader.feed(hiredis.writeCommand("hello", "world"));
+    assert.deepEqual(["hello", "world"], reader.get());
+});

--- a/test/writer.js
+++ b/test/writer.js
@@ -7,3 +7,23 @@ test("WriteCommand", function() {
     reader.feed(hiredis.writeCommand("hello", "world"));
     assert.deepEqual(["hello", "world"], reader.get());
 });
+
+test("WriteUnicode", function() {
+    var reader = new hiredis.Reader();
+    reader.feed(hiredis.writeCommand("béép"));
+    assert.deepEqual(["béép"], reader.get());
+});
+
+test("WriteBuffer", function() {
+    var reader = new hiredis.Reader({ return_buffers: true });
+    reader.feed(hiredis.writeCommand(new Buffer([0xC3, 0x28])));
+    var command = reader.get();
+    assert.equal(0xC3, command[0][0]);
+    assert.equal(0x28, command[0][1]);
+});
+
+test("WriteNumber", function() {
+    var reader = new hiredis.Reader();
+    reader.feed(hiredis.writeCommand(3));
+    assert.deepEqual(["3"], reader.get());
+});


### PR DESCRIPTION
I don't think this should be a problem API-wise:

 * The `write()` method signature was a variable number of string arguments, and this still works as is.
 * Other argument types were previously not supported. Now they are stringified and bufferified.
 * The `write()` method return value was `undefined`, but now returns the underlying socket `write()` method return value. (A boolean whether the data was immediately flushed.)

So if this breaks anything, they were doing funky unsupported stuff.