### PR TITLE
io.js support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "bindings": "*",
-    "nan": "~1.1.0"
+    "nan": "^1.5.1"
   },
   "engines": {
     "node": ">= 0.6.0"


### PR DESCRIPTION
Updates nan's minimum version to 1.5.1 which enables hiredis to build on io.js.

Tests pass minus the [already failing LargeIntegerReply test](https://github.com/redis/hiredis-node/blob/master/test/reader.js#L44-L48):

```js
// This test fails since v8 doesn't to 64-bit integers...
test("LargeIntegerReply", function() {
    var reader = new hiredis.Reader();
    reader.feed(":9223372036854775807\r\n");
    assert.equal("9223372036854775807", String(reader.get()));
});
```
```
> hiredis@0.1.17 test /Users/timoxley/Projects/libs/hiredis-node
> node test/reader.js

LargeIntegerReply failed!
AssertionError: "9223372036854775807" == "9223372036854776000"
    at /Users/timoxley/Projects/libs/hiredis-node/test/reader.js:47:12
    at test (/Users/timoxley/Projects/libs/hiredis-node/test/reader.js:9:9)
    at Object.<anonymous> (/Users/timoxley/Projects/libs/hiredis-node/test/reader.js:44:1)
    at Module._compile (module.js:446:26)
    at Object.Module._extensions..js (module.js:464:10)
    at Module.load (module.js:341:32)
    at Function.Module._load (module.js:296:12)
    at Function.Module.runMain (module.js:487:10)
    at startup (node.js:111:16)
    at node.js:809:3
```