### PR TITLE
Refactored to use only the parser from hiredis source.

### DIFF
--- a/deps/hiredis.gyp
+++ b/deps/hiredis.gyp
@@ -7,10 +7,7 @@
         'include_dirs': [ '.' ],
       },
       'sources': [
-        './hiredis/hiredis.c',
-        './hiredis/net.c',
         './hiredis/sds.c',
-        './hiredis/async.c',
         './hiredis/read.c',
       ],
       'conditions': [

--- a/src/reader.cc
+++ b/src/reader.cc
@@ -78,7 +78,7 @@ static redisReplyObjectFunctions v8ReplyFunctions = {
 Reader::Reader(bool return_buffers) :
     return_buffers(return_buffers)
 {
-    reader = redisReaderCreate();
+    reader = redisReaderCreateWithFunctions(NULL);
     reader->fn = &v8ReplyFunctions;
     reader->privdata = this;
 

--- a/src/reader.h
+++ b/src/reader.h
@@ -1,6 +1,6 @@
 #include <v8.h>
 #include <node.h>
-#include <hiredis/hiredis.h>
+#include <hiredis/read.h>
 #include "nan.h"
 
 #if NODE_MODULE_VERSION < 12


### PR DESCRIPTION
This removes uneeded dependencies between hiredis and hiredis-node, it keeps just the parser itself. Should be part of an effort to make hiredis-node compile as-is on windows.