### PR TITLE
Specify the BSD-3-Clause license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "licenses": [
     {
-      "type": "BSD",
+      "type": "BSD-3-Clause",
       "url": "https://github.com/redis/hiredis-node#license"
     }
   ]


### PR DESCRIPTION
NPM thinks the BSD-2-Clause is the intended one:
https://www.npmjs.com/package/hiredis