### PR TITLE
upgrade nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "bindings": "*",
-    "nan": "~1.5.0"
+    "nan": "^1.8.4"
   },
   "engines": {
     "node": ">= 0.8.0"


### PR DESCRIPTION
bump nan for iojs-2.0.0 compat
(I used the ^ so a republish isn't needed every release. see: https://github.com/iojs/io.js/issues/1620)