### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,5 @@
   "bugs": {
     "url": "https://github.com/redis/hiredis-node/issues"
   },
-  "licenses": [
-    {
-      "type": "BSD-3-Clause",
-      "url": "https://github.com/redis/hiredis-node#license"
-    }
-  ]
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/