### PR TITLE
Do not cast a potentially non-String value to String, use ToString() instead.

### DIFF
--- a/src/reader.cc
+++ b/src/reader.cc
@@ -52,7 +52,7 @@ static void *createString(const redisReadTask *task, char *str, size_t len) {
     Local<Value> v(r->createString(str,len));
 
     if (task->type == REDIS_REPLY_ERROR)
-        v = Exception::Error(v.As<String>());
+        v = Exception::Error(v->ToString());
     return tryParentize(task,v);
 }
 


### PR DESCRIPTION
Note that Reader::createString() may not return String, it may return a Buffer (when return_buffers is set to true). So, the variable 'v' may not hold String. Moreover, 'v.As<String>()' doesn't convert the value to String, it works more like a cast. Of course, it is incorrect to cast Buffer to String. Unfortunately, the non-debug version of Node.js has various checks turned off. So, you cannot see this issue normally, but when you execute tests on the debug version of Node.js, i.e., run node_g test/reader.js then you can see the following crash caused by the incorrect cast of 'v'.

```
#
# Fatal error in ../deps/v8/src/api.h, line 400
# Check failed: that == __null || (*reinterpret_cast<v8::internal::Object* const*>(that))->IsString().
#

==== C stack trace ===============================

 1: V8_Fatal
 2: v8::Utils::OpenHandle(v8::String const*, bool)
 3: v8::Exception::Error(v8::Local<v8::String>)
 4: 0x7efd7e262cb5
 5: redisReaderGetReply
 6: hiredis::Reader::Get(Nan::FunctionCallbackInfo<v8::Value> const&)
 7: 0x7efd7e2626c6
 8: v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&))
 9: 0xdeaebe
10: 0xde59ae
11: 0xde5919
12: 0x1a1e1b8060bb
Illegal instruction

```