### PR TITLE
Node 12 + upgrade hiredis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,10 @@
 language: node_js
 sudo: false
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-
-
-before_install:
-  - node --version | grep -q 'v0.8' && npm install -g npm@2 || true
 
 node_js:
-  - "6"
-  - "5"
-  - "4"
-  - "0.12"
-  - "0.10"
+  - "lts/erbium"
+  - "lts/dubnium"
+  - "stable"
 
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,20 +3,17 @@ init:
 
 environment:
   matrix:
-    - nodejs_version: 6
-    - nodejs_version: 5
-    - nodejs_version: 4
-    - nodejs_version: 0.12
-    - nodejs_version: 0.10
-
-platform:
-  - x86
-  - x64
+    - nodejs_version: "lts/erbium"
+    - nodejs_version: "lts/dubnium"
+    - nodejs_version: "stable"
 
 install:
-  - ps: Install-Product node $env:nodejs_version $env:platform
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
+  - set PATH=%APPDATA%\npm;%PATH%
+  - dir "C:\Program Files"
+  - dir "C:\Program Files (x86)"
+  - npm install
   - git submodule update --init --recursive
-  - npm install --msvs_version=2013
 
 build: off
 

--- a/src/reader.cc
+++ b/src/reader.cc
@@ -18,7 +18,7 @@ static void *tryParentize(const redisReadTask *task, const Local<Value> &v) {
         Local<Value> lvalue = Nan::New(r->handle[pidx]);
         assert(lvalue->IsArray());
         Local<Array> larray = lvalue.As<Array>();
-        larray->Set(task->idx,v);
+        Nan::Set(larray, task->idx, v);
 
         /* Store the handle when this is an inner array. Otherwise, hiredis
          * doesn't care about the return value as long as the value is set in
@@ -52,7 +52,7 @@ static void *createString(const redisReadTask *task, char *str, size_t len) {
     Local<Value> v(r->createString(str,len));
 
     if (task->type == REDIS_REPLY_ERROR)
-        v = Exception::Error(v->ToString());
+        v = Exception::Error(v->ToString(Nan::GetCurrentContext()).FromMaybe(v8::Local<v8::String>()));
     return tryParentize(task,v);
 }
 

--- a/src/reader.cc
+++ b/src/reader.cc
@@ -191,7 +191,7 @@ NAN_METHOD(Reader::Feed) {
             assert(redisReaderFeed(r->reader, data, length) == REDIS_OK);
         } else if (info[0]->IsString()) {
             Nan::Utf8String str(info[0].As<String>());
-            redisReplyReaderFeed(r->reader, *str, str.length());
+            redisReaderFeed(r->reader, *str, str.length());
         } else {
             Nan::ThrowError("Invalid argument");
         }


### PR DESCRIPTION
Hi!

We want to upgrade Node 12 LTS, and currently, hiredis-node doesn't support it.
This PR:
* Updates travis-ci configuration: to test again two latest LTS and stable, and remove old nodes configurations.
* Upgrade hiredis to 0.14.0 
* Support Node 12 due to deprecations

Notes:
* I ran this branch on our ci which includes lots of unit tests (there interacts with redis+hiredis) and full e2e tests and it passes.
* The "leaks" test is failing on my local computer (macOS Catalina 10.15), but I commented all tests and it's still failing so don't think it's related to my changes. 

Benchmarks:
```
# master

PING: 55248.62 ops/sec
SET: 59347.18 ops/sec
GET: 70671.38 ops/sec
LPUSH 8 bytes: 66225.17 ops/sec
LPUSH 64 bytes: 61162.08 ops/sec
LPUSH 512 bytes: 55096.42 ops/sec
LRANGE 10 elements, 8 bytes: 54794.52 ops/sec
LRANGE 100 elements, 8 bytes: 30911.90 ops/sec
LRANGE 100 elements, 64 bytes: 28490.03 ops/sec
LRANGE 100 elements, 512 bytes: 14847.81 ops/sec


# hiredis + node 12

PING: 61162.08 ops/sec
SET: 64308.68 ops/sec
GET: 74626.87 ops/sec
LPUSH 8 bytes: 69444.44 ops/sec
LPUSH 64 bytes: 71684.59 ops/sec
LPUSH 512 bytes: 70671.38 ops/sec
LRANGE 10 elements, 8 bytes: 58997.05 ops/sec
LRANGE 100 elements, 8 bytes: 30721.97 ops/sec
LRANGE 100 elements, 64 bytes: 28288.54 ops/sec
LRANGE 100 elements, 512 bytes: 16233.77 ops/sec
```